### PR TITLE
Fixed an issue with a undeletable block, the "zero" block

### DIFF
--- a/chunker.js
+++ b/chunker.js
@@ -75,7 +75,7 @@ Chunker.prototype.voxelAtPosition = function(pos, val) {
   if (!chunk) return false
   var vector = this.voxelVector(pos)
   var vidx = this.voxelIndex(vector)
-  if (!vidx) return false
+  if (!vidx && vidx !== 0) return false
   if (typeof val !== 'undefined') {
     chunk.voxels[vidx] = val
   }


### PR DESCRIPTION
I assume the origin of the if(!vidx), was to catch issues when vidx is undefined or null.
However, it creates a "zero-brick" undeletable bug...

There is a brick that is undeletable, this is because vidx is genuinely equal to 0

For an example, see issue no. 10 in voxel-engine: https://github.com/maxogden/voxel-engine/issues/10 
