### PR TITLE
Ndarray

### DIFF
--- a/chunker.js
+++ b/chunker.js
@@ -92,11 +92,6 @@ Chunker.prototype.voxelIndexFromCoordinates = function(x, y, z) {
   return vidx
 }
 
-Chunker.prototype.voxelIndexFromPosition = function(pos) {
-  var v = this.voxelVector(pos)
-  return this.voxelIndex(v)
-}
-
 Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var ckey = this.chunkAtCoordinates(x, y, z).join('|')
   var chunk = this.chunks[ckey]
@@ -118,18 +113,3 @@ Chunker.prototype.voxelAtPosition = function(pos, val) {
   return v;
 }
 
-// deprecated
-Chunker.prototype.voxelIndex = function(voxelVector) {
-  var vidx = this.voxelIndexFromCoordinates(voxelVector[0], voxelVector[1], voxelVector[2])
-  return vidx
-}
-
-// deprecated
-Chunker.prototype.voxelVector = function(pos) {
-  var cubeSize = this.cubeSize
-  var mask = (1 << this.chunkBits) - 1
-  var vx = (Math.floor(pos[0] / cubeSize)) & mask
-  var vy = (Math.floor(pos[1] / cubeSize)) & mask
-  var vz = (Math.floor(pos[2] / cubeSize)) & mask
-  return [vx, vy, vz]
-};

--- a/chunker.js
+++ b/chunker.js
@@ -102,9 +102,9 @@ Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var chunk = this.chunks[ckey]
   if (!chunk) return false
   var vidx = this.voxelIndexFromCoordinates(x, y, z)
-  var v = chunk.voxels[vidx]
+  var v = chunk.data[vidx]
   if (typeof val !== 'undefined') {
-    chunk.voxels[vidx] = val
+    chunk.data[vidx] = val
   }
   return v
 }

--- a/chunker.js
+++ b/chunker.js
@@ -93,9 +93,13 @@ Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var ckey = this.chunkAtCoordinates(x, y, z).join('|')
   var chunk = this.chunks[ckey]
   if (!chunk) return false
-  var v = chunk.get(z, y, x)
+  var mask = (1 << this.chunkBits) -1
+  var mx = x & mask
+  var my = y & mask
+  var mz = z & mask
+  var v = chunk.get(mz, my, mx)
   if (typeof val !== 'undefined') {
-    chunk.set(z, y, x, val)
+    chunk.set(mz, my, mx, val)
   }
   return v
 }

--- a/chunker.js
+++ b/chunker.js
@@ -93,9 +93,9 @@ Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var ckey = this.chunkAtCoordinates(x, y, z).join('|')
   var chunk = this.chunks[ckey]
   if (!chunk) return false
-  var v = chunk.get(x, y, z)
+  var v = chunk.get(z, y, x)
   if (typeof val !== 'undefined') {
-    chunk.set(x, y, z, val)
+    chunk.set(z, y, x, val)
   }
   return v
 }

--- a/chunker.js
+++ b/chunker.js
@@ -86,20 +86,16 @@ Chunker.prototype.chunkAtPosition = function(position) {
 };
 
 Chunker.prototype.voxelIndexFromCoordinates = function(x, y, z) {
-  var bits = this.chunkBits
-  var mask = (1 << bits) - 1
-  var vidx = (x & mask) + ((y & mask) << bits) + ((z & mask) << bits * 2)
-  return vidx
+  throw new Error('Chunker.prototype.voxelIndexFromCoordinates removed, use voxelAtCoordinates')
 }
 
 Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var ckey = this.chunkAtCoordinates(x, y, z).join('|')
   var chunk = this.chunks[ckey]
   if (!chunk) return false
-  var vidx = this.voxelIndexFromCoordinates(x, y, z)
-  var v = chunk.data[vidx]
+  var v = chunk.get(x, y, z)
   if (typeof val !== 'undefined') {
-    chunk.data[vidx] = val
+    chunk.set(x, y, z, val)
   }
   return v
 }

--- a/chunker.js
+++ b/chunker.js
@@ -10,6 +10,7 @@ module.exports.Chunker = Chunker
 function Chunker(opts) {
   this.distance = opts.chunkDistance || 2
   this.chunkSize = opts.chunkSize || 32
+  this.chunkPad = opts.chunkPad !== undefined ? opts.chunkPad : 4
   this.cubeSize = opts.cubeSize || 25
   this.generateVoxelChunk = opts.generateVoxelChunk
   this.chunks = {}
@@ -20,6 +21,8 @@ function Chunker(opts) {
   var bits = 0;
   for (var size = this.chunkSize; size > 0; size >>= 1) bits++;
   this.chunkBits = bits - 1;
+  this.chunkMask = (1 << this.chunkBits) - 1
+  this.chunkPadHalf = this.chunkPad >> 1
 }
 
 inherits(Chunker, events.EventEmitter)
@@ -93,13 +96,14 @@ Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var ckey = this.chunkAtCoordinates(x, y, z).join('|')
   var chunk = this.chunks[ckey]
   if (!chunk) return false
-  var mask = (1 << this.chunkBits) -1
+  var mask = this.chunkMask
+  var h = this.chunkPadHalf
   var mx = x & mask
   var my = y & mask
   var mz = z & mask
-  var v = chunk.get(mz, my, mx)
+  var v = chunk.get(mz+h, my+h, mx+h)
   if (typeof val !== 'undefined') {
-    chunk.set(mz, my, mx, val)
+    chunk.set(mz+h, my+h, mx+h, val)
   }
   return v
 }

--- a/chunker.js
+++ b/chunker.js
@@ -101,9 +101,9 @@ Chunker.prototype.voxelAtCoordinates = function(x, y, z, val) {
   var mx = x & mask
   var my = y & mask
   var mz = z & mask
-  var v = chunk.get(mz+h, my+h, mx+h)
+  var v = chunk.get(mx+h, my+h, mz+h)
   if (typeof val !== 'undefined') {
-    chunk.set(mz+h, my+h, mx+h, val)
+    chunk.set(mx+h, my+h, mz+h, val)
   }
   return v
 }

--- a/chunker.js
+++ b/chunker.js
@@ -10,7 +10,7 @@ module.exports.Chunker = Chunker
 function Chunker(opts) {
   this.distance = opts.chunkDistance || 2
   this.chunkSize = opts.chunkSize || 32
-  this.chunkPad = opts.chunkPad !== undefined ? opts.chunkPad : 4
+  this.chunkPad = opts.chunkPad !== undefined ? opts.chunkPad : 0
   this.cubeSize = opts.cubeSize || 25
   this.generateVoxelChunk = opts.generateVoxelChunk
   this.chunks = {}

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function generate(lo, hi, fn, game) {
   hi[0]++
   hi[1]++
   hi[2]++
-  var dims = [hi[0]-lo[0], hi[1]-lo[1], hi[2]-lo[2]]
-  var data = ndarray(new Uint16Array(dims[0] * dims[1] * dims[2]), dims)
+  var dims = [hi[2]-lo[2], hi[1]-lo[1], hi[0]-lo[0]]
+  var data = ndarray(new Uint16Array(dims[2] * dims[1] * dims[0]), dims)
   for (var n = 0, k = lo[2]; k < hi[2]; k++)
     for (var j = lo[1]; j < hi[1]; j++)
       for(var i = lo[0]; i < hi[0]; i++, n++) {

--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ function generate(lo, hi, fn, game) {
   hi[2]++
   var dims = [hi[2]-lo[2], hi[1]-lo[1], hi[0]-lo[0]]
   var data = ndarray(new Uint16Array(dims[2] * dims[1] * dims[0]), dims)
-  for (var n = 0, k = lo[2]; k < hi[2]; k++)
+  for (var k = lo[2]; k < hi[2]; k++)
     for (var j = lo[1]; j < hi[1]; j++)
-      for(var i = lo[0]; i < hi[0]; i++, n++) {
-        data.data[n] = fn(i, j, k, n, game)
+      for(var i = lo[0]; i < hi[0]; i++) {
+        data.set(k-lo[2], j-lo[1], i-lo[0], fn(i, j, k))
       }
   return data
 }

--- a/index.js
+++ b/index.js
@@ -22,22 +22,15 @@ module.exports.generator = {}
 module.exports.generate = generate
 
 function generate(lo, hi, fn, game) {
-  // PROBLEM:
   // To fix the display gaps, we need to pad the bounds
-  // ndarrays are generated with x,y,z but here (and physics) want z,y,x
-  /*lo[0]--
+  lo[0]--
   lo[1]--
   lo[2]--
   hi[0]++
   hi[1]++
-  hi[2]++*/
+  hi[2]++
   var dims = [hi[0]-lo[0], hi[1]-lo[1], hi[2]-lo[2]]
   var data = ndarray(new Uint16Array(dims[0] * dims[1] * dims[2]), dims)
-  //var n = 0
-  /*for (var x = lo[0]; x < hi[0]; x++)
-    for (var y = lo[1]; y < hi[1]; y++)
-      for (var z = lo[2]; z < hi[2]; z++) {
-        data.data[n++] = fn(x, y, z, n, game)*/
   for (var n = 0, k = lo[2]; k < hi[2]; k++)
     for (var j = lo[1]; j < hi[1]; j++)
       for(var i = lo[0]; i < hi[0]; i++, n++) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var chunker = require('./chunker')
+var ndarray = require('ndarray')
 
 module.exports = function(opts) {
   if (!opts.generateVoxelChunk) opts.generateVoxelChunk = function(low, high) {
@@ -20,17 +21,29 @@ module.exports.geometry = {}
 module.exports.generator = {}
 module.exports.generate = generate
 
-// from https://github.com/mikolalysenko/mikolalysenko.github.com/blob/master/MinecraftMeshes2/js/testdata.js#L4
-function generate(l, h, f, game) {
-  var d = [ h[0]-l[0], h[1]-l[1], h[2]-l[2] ]
-  var v = new Int8Array(d[0]*d[1]*d[2])
-  var n = 0
-  for(var k=l[2]; k<h[2]; ++k)
-  for(var j=l[1]; j<h[1]; ++j)
-  for(var i=l[0]; i<h[0]; ++i, ++n) {
-    v[n] = f(i,j,k,n,game)
-  }
-  return {voxels:v, dims:d}
+function generate(lo, hi, fn, game) {
+  // PROBLEM:
+  // To fix the display gaps, we need to pad the bounds
+  // ndarrays are generated with x,y,z but here (and physics) want z,y,x
+  /*lo[0]--
+  lo[1]--
+  lo[2]--
+  hi[0]++
+  hi[1]++
+  hi[2]++*/
+  var dims = [hi[0]-lo[0], hi[1]-lo[1], hi[2]-lo[2]]
+  var data = ndarray(new Uint16Array(dims[0] * dims[1] * dims[2]), dims)
+  //var n = 0
+  /*for (var x = lo[0]; x < hi[0]; x++)
+    for (var y = lo[1]; y < hi[1]; y++)
+      for (var z = lo[2]; z < hi[2]; z++) {
+        data.data[n++] = fn(x, y, z, n, game)*/
+  for (var n = 0, k = lo[2]; k < hi[2]; k++)
+    for (var j = lo[1]; j < hi[1]; j++)
+      for(var i = lo[0]; i < hi[0]; i++, n++) {
+        data.data[n] = fn(i, j, k, n, game)
+      }
+  return data
 }
 
 // shape and terrain generator functions
@@ -55,7 +68,7 @@ module.exports.generator['Hill'] = function(i,j,k) {
 }
 
 module.exports.generator['Valley'] = function(i,j,k) {
-  return j <= (i*i + k*k) * 31 / (32*32*2) + 1 ? 1 : 0;
+  return j <= (i*i + k*k) * 31 / (32*32*2) + 1 ? 1 + (1<<15) : 0;
 }
 
 module.exports.generator['Hilly Terrain'] = function(i,j,k) {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
   "devDependencies": {
     "microtime": "~0.3.3",
     "tape": "0.2.2"
-  },
-  "peerDependencies": {
-    "voxel-engine": ">=0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.4.0",
   "main": "index.js",
   "dependencies": {
-    "inherits": "1.0.0"
+    "inherits": "1.0.0",
+    "ndarray": "~1.0.5"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -50,17 +50,6 @@ test('voxelIndexFromCoordinates', function (t) {
   t.end()
 })
 
-test('voxelIndexFromPosition', function (t) {
-  var chunker = voxel({chunkDistance: 2, chunkSize: 32, cubeSize: 1})
-  t.equal(chunker.voxelIndexFromPosition([0, 0, 0]), 0)
-  t.equal(chunker.voxelIndexFromPosition([0.9999, 0, 0]), 0)
-  t.equal(chunker.voxelIndexFromPosition([1.9999, 0, 0]), 1)
-  t.equal(chunker.voxelIndexFromPosition([-0.0001, 0, 0]), 31)
-  t.equal(chunker.voxelIndexFromPosition([-0.9999, 0, 0]), 31)
-  t.equal(chunker.voxelIndexFromPosition([-1, 0, 0]), 31)
-  t.end()
-})
-
 test('getBounds', function (t) {
   var chunker = voxel({chunkDistance: 2, chunkSize: 32, cubeSize: 1})
   t.deepEqual(chunker.getBounds(0, 0, 0), [[0, 0, 0], [32, 32, 32]])

--- a/test.js
+++ b/test.js
@@ -32,24 +32,6 @@ test('chunkAtPosition', function (t) {
   t.end()
 })
 
-test('voxelIndexFromCoordinates', function (t) {
-  var chunker = voxel({chunkDistance: 2, chunkSize: 32, cubeSize: 1})
-  t.equal(chunker.voxelIndexFromCoordinates(0, 0, 0), 0)
-  t.equal(chunker.voxelIndexFromCoordinates(1, 0, 0), 1)
-  t.equal(chunker.voxelIndexFromCoordinates(31, 0, 0), 31)
-  t.equal(chunker.voxelIndexFromCoordinates(32, 0, 0), 0)
-  t.equal(chunker.voxelIndexFromCoordinates(0, 1, 0), 32) 
-  t.equal(chunker.voxelIndexFromCoordinates(0, 31, 0), 32*31)
-  t.equal(chunker.voxelIndexFromCoordinates(0, 32, 0), 0)
-  t.equal(chunker.voxelIndexFromCoordinates(0, 0, 1), 32*32) 
-  t.equal(chunker.voxelIndexFromCoordinates(0, 0, 31), 32*32*31)
-  t.equal(chunker.voxelIndexFromCoordinates(0, 0, 32), 0)
-  t.equal(chunker.voxelIndexFromCoordinates(-1, 0, 0), 31)
-  t.equal(chunker.voxelIndexFromCoordinates(-31, 0, 0), 1)
-  t.equal(chunker.voxelIndexFromCoordinates(-32, 0, 0), 0)
-  t.end()
-})
-
 test('getBounds', function (t) {
   var chunker = voxel({chunkDistance: 2, chunkSize: 32, cubeSize: 1})
   t.deepEqual(chunker.getBounds(0, 0, 0), [[0, 0, 0], [32, 32, 32]])


### PR DESCRIPTION
Converts to use [ndarray](https://github.com/mikolalysenko/ndarray) for the voxel format. This is independent of gl-now integration, but any chunk generators would have to update (not backwards-compatible. example update in https://github.com/deathcap/voxel-land/commit/c01750c3d44e57a33f041b99014e74565155ffe8). feedback welcome

(note: `meshers/` are not needed for the gl-modules port (meshing implemented instead in [voxel-mesher](https://github.com/deathcap/voxel-mesher)), but I left them in for three.js-based voxel-engine compatibility)

ref https://github.com/voxel/issues/issues/4 ndarray/gl-now integration
